### PR TITLE
Add Readme line about defaults files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ The pandoc-xnos filter suite may be applied using the
 
 option with pandoc.  It is also possible to apply the filters individually.
 
-Any use of `--filter pandoc-citeproc` or `--bibliography=FILE` should come *after* the `pandoc-xnos` filter call.
+Any use of `--filter pandoc-citeproc` or `--bibliography=FILE` should come *after* the `pandoc-xnos` filter call. If you're using a defaults.yml file use the filter form of citeproc:
+```
+filters:
+  - pandoc-xnos
+  - citeproc
+```
+and do not include `citeproc: true` anywhere in the yml file as this will cause citeproc to complain that it cannot find your figure references. 
 
 
 Getting Help


### PR DESCRIPTION
Love the package. 

I found that I was getting spurious errors where citeproc would complain that with the error 
```
[WARNING] Citeproc: citation fig:label not found
```

This issue is that I was using `citeproc: true` in my defaults file on the assumption that this would cause citeproc to be run after all the filters. This seems not to be the case.

Switching to using
```
filters:
  - pandoc-xnos
  - citeproc
```

Solves this for me. The use of defaults files is not super well documented in the main pandoc documentation.